### PR TITLE
Rename MindManager references to LocalAgentManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a lightweight Godot plug-in and Python tooling that int
 
 The project ships with:
 
-- A Godot 4 plug-in that exposes a `MindManager` autoload and `MindAgent` node written entirely in GDScript.
+- A Godot 4 plug-in that exposes a `LocalAgentManager` autoload and `MindAgent` node written entirely in GDScript.
 - A reusable Python CLI (`scripts/run_inference.py`) that executes llama.cpp inference via the Python bindings.
 - A packaged llama.cpp model catalog with helpers for listing families and downloading GGUF artifacts.
 - An automated test that downloads the Qwen3-0.6B-Instruct model, performs a short chat completion, and asserts that text is produced.
@@ -27,8 +27,13 @@ The project ships with:
    ```
    The script stores models inside `.models/` by default; use `--model` to target a specific `.gguf` file if you already have one locally.
 3. Open the Godot project (`project.godot`) and enable the **LocalAgents** plug-in.
-4. Configure the `MindManager` autoload with the path to your `.gguf` file (for example `res://.models/Qwen3-0.6B-Instruct-Q4_K_M.gguf`).
+4. Configure the `LocalAgentManager` autoload with the path to your `.gguf` file (for example `res://.models/Qwen3-0.6B-Instruct-Q4_K_M.gguf`). You can edit the new **Model Path** property directly from the autoload inspector or drop a `LocalAgentManagerNode` into any scene to manage the singleton from the regular node tree.
 5. Run the bundled `chat_example.tscn` scene to exchange prompts with the locally hosted model.
+
+### Configuring the LocalAgentManager singleton
+
+- The `LocalAgentManager` autoload script now exposes a **Model Path** property so you can configure the active GGUF file from the Project Settings → Autoload inspector without writing code.
+- A companion `LocalAgentManagerNode` is available from the "Add Child Node" dialog. Drop it into a scene to mirror or override the singleton configuration when running entirely in-game.
 
 ### Discovering additional models
 

--- a/addons/mind_game/mind_agent/mind_agent.gd
+++ b/addons/mind_game/mind_agent/mind_agent.gd
@@ -7,19 +7,19 @@ signal error_received(message)
 @export var prompt_prefix: String = ""
 @export var system_prompt: String = "You are a helpful in-game assistant."
 
-var _manager: MindManager
+var _manager: LocalAgentManager
 
 func _ready() -> void:
-    _manager = get_node_or_null("/root/MindManager")
+    _manager = get_node_or_null("/root/LocalAgentManager")
     if _manager:
         _manager.connect("inference_finished", _on_inference_finished)
         _manager.connect("inference_failed", _on_inference_failed)
     else:
-        push_warning("MindManager autoload is not present.")
+        push_warning("LocalAgentManager autoload is not present.")
 
 func send_message(message: String, max_tokens: int = 128, temperature: float = 0.7) -> void:
     if not _manager:
-        emit_signal("error_received", "MindManager is unavailable")
+        emit_signal("error_received", "LocalAgentManager is unavailable")
         return
     var full_prompt := message if prompt_prefix.is_empty() else prompt_prefix + "\n" + message
     _manager.generate_response(full_prompt, max_tokens, temperature, system_prompt)

--- a/addons/mind_game/mind_game_editor_plugin.gd
+++ b/addons/mind_game/mind_game_editor_plugin.gd
@@ -1,7 +1,7 @@
 extends EditorPlugin
 
-const AUTOLOAD_NAME := "MindManager"
-const AUTOLOAD_PATH := "res://addons/mind_game/mind_manager/mind_manager.gd"
+const AUTOLOAD_NAME := "LocalAgentManager"
+const AUTOLOAD_PATH := "res://addons/mind_game/mind_manager/local_agent_manager.gd"
 const PANEL_SCENE := preload("res://addons/mind_game/ui/local_agents_panel.tscn")
 
 var _autoload_added := false

--- a/addons/mind_game/mind_game_editor_plugin.gd
+++ b/addons/mind_game/mind_game_editor_plugin.gd
@@ -2,17 +2,21 @@ extends EditorPlugin
 
 const AUTOLOAD_NAME := "LocalAgentManager"
 const AUTOLOAD_PATH := "res://addons/mind_game/mind_manager/local_agent_manager.gd"
+const LEGACY_AUTOLOAD_NAME := "MindManager"
+const LEGACY_AUTOLOAD_PATH := "res://addons/mind_game/mind_manager/mind_manager.gd"
 const PANEL_SCENE := preload("res://addons/mind_game/ui/local_agents_panel.tscn")
 
 var _autoload_added := false
 var _panel_instance: Control
 
 func _enter_tree() -> void:
+    _autoload_added = false
+
+    _migrate_legacy_autoload()
+
     if not Engine.has_singleton(AUTOLOAD_NAME) and not ProjectSettings.has_setting("autoload/" + AUTOLOAD_NAME):
         add_autoload_singleton(AUTOLOAD_NAME, AUTOLOAD_PATH)
         _autoload_added = true
-    else:
-        _autoload_added = false
 
     if PANEL_SCENE:
         _panel_instance = PANEL_SCENE.instantiate()
@@ -25,3 +29,36 @@ func _exit_tree() -> void:
         remove_control_from_bottom_panel(_panel_instance)
         _panel_instance.queue_free()
         _panel_instance = null
+
+func _migrate_legacy_autoload() -> void:
+    if not ProjectSettings.has_setting("autoload/" + LEGACY_AUTOLOAD_NAME):
+        return
+
+    var autoload_setting := ProjectSettings.get_setting("autoload/" + LEGACY_AUTOLOAD_NAME)
+    var autoload_path := _get_autoload_path(autoload_setting)
+
+    if autoload_path != LEGACY_AUTOLOAD_PATH:
+        return
+
+    remove_autoload_singleton(LEGACY_AUTOLOAD_NAME)
+
+    if not ProjectSettings.has_setting("autoload/" + AUTOLOAD_NAME):
+        add_autoload_singleton(AUTOLOAD_NAME, AUTOLOAD_PATH)
+
+func _get_autoload_path(setting) -> String:
+    match typeof(setting):
+        TYPE_DICTIONARY:
+            var path_value = setting.get("path", "")
+            if typeof(path_value) == TYPE_STRING:
+                return _sanitize_autoload_path(path_value)
+            return ""
+        TYPE_STRING:
+            return _sanitize_autoload_path(setting)
+        _:
+            return ""
+
+func _sanitize_autoload_path(path_value: String) -> String:
+    var path := path_value
+    if path.begins_with("*"):
+        path = path.substr(1)
+    return path

--- a/addons/mind_game/mind_manager/local_agent_manager.gd
+++ b/addons/mind_game/mind_manager/local_agent_manager.gd
@@ -1,5 +1,6 @@
+@tool
 extends Node
-class_name MindManager
+class_name LocalAgentManager
 
 signal model_changed(model_path)
 signal inference_finished(response)
@@ -8,7 +9,12 @@ signal inference_failed(error_message)
 const DEFAULT_SCRIPT := "res://scripts/run_inference.py"
 const PYTHON_ENV_VAR := "LOCAL_AGENTS_PYTHON"
 
-var model_path: String = ""
+var _model_path: String = ""
+@export_file("*") var model_path: String = "":
+    set(value):
+        set_model_path(value)
+    get:
+        return _model_path
 var inference_script: String = DEFAULT_SCRIPT
 var python_executable: String = ""
 var last_response: String = ""
@@ -17,6 +23,8 @@ func _ready() -> void:
     python_executable = OS.get_environment(PYTHON_ENV_VAR)
     if python_executable == "":
         python_executable = "python3"
+    if not _model_path.is_empty():
+        load_model(_model_path)
 
 func set_inference_script(script_path: String) -> void:
     inference_script = script_path
@@ -28,11 +36,22 @@ func load_model(path: String) -> void:
     if path.is_empty():
         emit_signal("inference_failed", "Model path cannot be empty")
         return
-    model_path = path
+    _model_path = path
     emit_signal("model_changed", path)
 
 func unload_model() -> void:
-    model_path = ""
+    var was_loaded := not _model_path.is_empty()
+    _model_path = ""
+    if was_loaded:
+        emit_signal("model_changed", _model_path)
+
+func set_model_path(path: String) -> void:
+    if path == _model_path:
+        return
+    if path.is_empty():
+        unload_model()
+        return
+    load_model(path)
 
 func generate_response(prompt: String, max_tokens: int = 128, temperature: float = 0.7, system_prompt: String = "You are a helpful assistant.") -> void:
     if model_path.is_empty():
@@ -42,7 +61,7 @@ func generate_response(prompt: String, max_tokens: int = 128, temperature: float
         emit_signal("inference_failed", "Prompt cannot be empty")
         return
     var script_path := ProjectSettings.globalize_path(inference_script)
-    var model := ProjectSettings.globalize_path(model_path)
+    var model := ProjectSettings.globalize_path(_model_path)
     var args := PackedStringArray([script_path, "--model", model, "--prompt", prompt, "--system", system_prompt, "--max-tokens", str(max_tokens), "--temperature", str(temperature)])
     var std_out: Array = []
     var exit_code := OS.execute(python_executable, args, std_out, true)

--- a/addons/mind_game/mind_manager/local_agent_manager_node.gd
+++ b/addons/mind_game/mind_manager/local_agent_manager_node.gd
@@ -1,0 +1,102 @@
+@tool
+extends Node
+class_name LocalAgentManagerNode
+
+var _model_path: String = ""
+var _manager_cache: LocalAgentManager
+var _is_syncing: bool = false
+
+@export_file("*") var model_path: String = "":
+    set(value):
+        if value == _model_path:
+            return
+        _model_path = value
+        if _is_syncing:
+            return
+        if _should_auto_apply():
+            _apply_model_path()
+    get:
+        return _model_path
+
+@export var auto_apply_on_ready: bool = true
+@export var apply_in_editor: bool = true
+
+func _enter_tree() -> void:
+    var manager := _get_manager()
+    if manager:
+        var callable := Callable(self, "_on_manager_model_changed")
+        if not manager.model_changed.is_connected(callable):
+            manager.model_changed.connect(callable)
+        if auto_apply_on_ready:
+            if _model_path.strip_edges().is_empty():
+                _sync_from_manager()
+            else:
+                _apply_model_path()
+        else:
+            _sync_from_manager()
+    elif auto_apply_on_ready:
+        _apply_model_path()
+
+func _exit_tree() -> void:
+    var manager := _get_manager()
+    if manager:
+        var callable := Callable(self, "_on_manager_model_changed")
+        if manager.model_changed.is_connected(callable):
+            manager.model_changed.disconnect(callable)
+    _manager_cache = null
+
+func _should_auto_apply() -> bool:
+    if Engine.is_editor_hint():
+        return apply_in_editor and _manager_available()
+    return _manager_available()
+
+func apply_model_path() -> void:
+    _apply_model_path()
+
+func sync_from_singleton() -> void:
+    _sync_from_manager()
+
+func _apply_model_path() -> void:
+    var manager := _get_manager()
+    if not manager:
+        return
+    if _model_path.strip_edges().is_empty():
+        manager.unload_model()
+    else:
+        manager.set_model_path(_model_path)
+
+func _sync_from_manager() -> void:
+    var manager := _get_manager()
+    if not manager:
+        return
+    if manager.model_path == _model_path:
+        return
+    _is_syncing = true
+    model_path = manager.model_path
+    _is_syncing = false
+
+func _on_manager_model_changed(path: String) -> void:
+    if path == _model_path:
+        return
+    _is_syncing = true
+    model_path = path
+    _is_syncing = false
+
+func _manager_available() -> bool:
+    return _get_manager() != null
+
+func _get_manager() -> LocalAgentManager:
+    if _manager_cache and is_instance_valid(_manager_cache):
+        return _manager_cache
+    if Engine.has_singleton("LocalAgentManager"):
+        var singleton := Engine.get_singleton("LocalAgentManager")
+        if singleton is LocalAgentManager:
+            _manager_cache = singleton
+            return _manager_cache
+    if is_inside_tree():
+        var root := get_tree().root
+        var node := root.get_node_or_null("LocalAgentManager")
+        if node is LocalAgentManager:
+            _manager_cache = node
+            return _manager_cache
+    return null

--- a/addons/mind_game/ui/model_download_panel.gd
+++ b/addons/mind_game/ui/model_download_panel.gd
@@ -173,7 +173,7 @@ func _on_download_pressed() -> void:
         cache_dir = ProjectSettings.globalize_path(DEFAULT_CACHE_DIR)
     var python_executable := _resolve_python()
     if python_executable == "":
-        _status_label.text = "Python executable could not be determined. Configure MindManager first."
+        _status_label.text = "Python executable could not be determined. Configure LocalAgentManager first."
         return
     var script_path := ProjectSettings.globalize_path(DOWNLOAD_SCRIPT)
     var args := PackedStringArray([script_path, "--family", str(family_id)])
@@ -195,14 +195,14 @@ func _on_download_pressed() -> void:
     set_process(true)
 
 func _resolve_python() -> String:
-    if Engine.has_singleton("MindManager"):
-        var manager = Engine.get_singleton("MindManager")
+    if Engine.has_singleton("LocalAgentManager"):
+        var manager = Engine.get_singleton("LocalAgentManager")
         if manager != null:
             var exe = manager.get("python_executable")
             if typeof(exe) == TYPE_STRING and exe != "":
                 return exe
-    if has_node("/root/MindManager"):
-        var manager_node = get_node("/root/MindManager")
+    if has_node("/root/LocalAgentManager"):
+        var manager_node = get_node("/root/LocalAgentManager")
         if manager_node != null:
             var exe_node = manager_node.get("python_executable")
             if typeof(exe_node) == TYPE_STRING and exe_node != "":


### PR DESCRIPTION
## Summary
- rename the MindManager autoload to LocalAgentManager and update all scripts to reference the new singleton name
- rename the helper node to LocalAgentManagerNode and update documentation accordingly

## Testing
- not run (Godot-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e7da990c5883298600ad07c8ab390f