### PR TITLE
Add comprehensive Local Agents test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The editor Download tab now lists the latest Qwen3 GGUF drops by family and para
 - The optional `addons/local_agents/graph/ProjectGraphService.gd` scans source folders, maps directory → file relationships as graph edges, and stores embeddings for each file chunk. This lays the groundwork for project-aware assistance and cross-referencing between code and conversation memories.
 
 ## Testing
-Headless scripts cover the new data layer and helper services. After building the GDExtension you can run everything with:
+Headless scripts cover the data layer, agent utilities, integration points, and optional runtime smoke tests. After building the GDExtension you can run everything with:
 
 ```bash
 scripts/run_tests.sh
@@ -53,12 +53,17 @@ scripts/run_tests.sh
 Set `GODOT_BIN` if your Godot 4 binary is not on `PATH`. The helper iterates through:
 
 ```bash
-godot --headless -s addons/local_agents/tests/test_network_graph.gd
+godot --headless -s addons/local_agents/tests/test_smoke_agent.gd
+godot --headless -s addons/local_agents/tests/test_agent_utilities.gd
+godot --headless -s addons/local_agents/tests/test_agent_integration.gd
 godot --headless -s addons/local_agents/tests/test_conversation_store.gd
 godot --headless -s addons/local_agents/tests/test_project_graph_service.gd
+godot --headless -s addons/local_agents/tests/test_network_graph.gd
+godot --headless -s addons/local_agents/tests/test_agent_e2e.gd
+godot --headless -s addons/local_agents/tests/test_agent_runtime_heavy.gd
 ```
 
-The tests use lightweight mock runtimes for embeddings, so no GGUF models are required. They create and clean up temporary data under `user://local_agents`. Before running the suites the helper calls `scripts/run_godot_check.sh` to ensure all plugin scripts parse.
+The smoke/unit/integration/e2e suites rely on lightweight mock runtimes for embeddings, so no GGUF models are required. The heavy runtime script is skipped unless you export `LOCAL_AGENTS_TEST_GGUF` to point at a small llama.cpp-compatible model, in which case it attempts a real load + inference cycle. All tests create and clean up temporary data under `user://local_agents`. Before running the suites the helper calls `scripts/run_godot_check.sh` to ensure all plugin scripts parse.
 
 ## Editor Check
 Before opening Godot (or after tweaking any `.gd` scripts), run the quick headless validation to catch parse/type issues and plugin wiring errors:

--- a/addons/local_agents/tests/test_agent_e2e.gd
+++ b/addons/local_agents/tests/test_agent_e2e.gd
@@ -1,0 +1,133 @@
+@tool
+extends SceneTree
+
+var _model_outputs: Array = []
+
+class MockRuntime:
+    func is_model_loaded() -> bool:
+        return true
+
+    func embed_text(text: String, options := {}) -> PackedFloat32Array:
+        var normalized := text.to_lower()
+        var score_a := float(normalized.count("assistant"))
+        var score_b := float(normalized.length()) / 100.0
+        return PackedFloat32Array([score_a, score_b, 1.0])
+
+class MockAgentNode:
+    extends Node
+
+    var history: Array = []
+
+    func think(prompt: String, extra_options := {}) -> Dictionary:
+        history.append({"role": "user", "content": prompt})
+        var reply := "Agent reply: %s" % prompt.strip_edges()
+        history.append({"role": "assistant", "content": reply})
+        return {
+            "ok": true,
+            "text": reply,
+        }
+
+    func add_message(role: String, content: String) -> void:
+        history.append({"role": role, "content": content})
+
+    func get_history() -> Array:
+        var copy: Array = []
+        for entry in history:
+            copy.append(entry.duplicate(true))
+        return copy
+
+    func clear_history() -> void:
+        history.clear()
+
+    func say(text: String, options := {}) -> bool:
+        return true
+
+    func listen(options := {}) -> String:
+        return ""
+
+    func enqueue_action(name: String, params := {}) -> void:
+        pass
+
+func _init() -> void:
+    if not ClassDB.class_exists("NetworkGraph"):
+        push_error("NetworkGraph class unavailable. Build the GDExtension before running tests.")
+        quit()
+        return
+
+    var store := LocalAgentsConversationStore.new()
+    get_root().add_child(store)
+    store._runtime = MockRuntime.new()
+    store.clear_all()
+
+    var conversation := store.create_conversation("End to End Chat")
+    assert(not conversation.is_empty())
+    var conversation_id := int(conversation.get("id", -1))
+    assert(conversation_id != -1)
+
+    var agent := LocalAgentsAgent.new()
+    var agent_node := MockAgentNode.new()
+    agent.agent_node = agent_node
+    agent.connect("model_output_received", Callable(self, "_on_model_output"))
+
+    var prompt := "Assistant, respond to this message"
+    store.append_message(conversation_id, "user", prompt, {})
+
+    var response := agent.think(prompt)
+    var reply := String(response.get("text", ""))
+    assert(reply != "")
+    assert(_model_outputs.size() == 1)
+
+    store.append_message(conversation_id, "assistant", reply, {})
+
+    var loaded := store.load_conversation(conversation_id)
+    var messages: Array = loaded.get("messages", [])
+    assert(messages.size() == 2)
+    assert(messages[1].get("role") == "assistant")
+    assert(messages[1].get("content") == reply)
+
+    var hits := store.search_messages("assistant", 4, 8)
+    assert(hits.size() >= 1)
+    assert(hits[0].get("role") == "assistant")
+
+    store.clear_all()
+    _cleanup_store(store)
+
+    agent.queue_free()
+    store.queue_free()
+
+    print("Local Agents end-to-end conversation test passed")
+    quit()
+
+func _on_model_output(text: String) -> void:
+    _model_outputs.append(text)
+
+func _cleanup_store(store: LocalAgentsConversationStore) -> void:
+    if store._graph:
+        store._graph.close()
+    var db_abs := ProjectSettings.globalize_path(store.DB_PATH)
+    if FileAccess.file_exists(db_abs):
+        DirAccess.remove_absolute(db_abs)
+    var dir_abs := ProjectSettings.globalize_path(store.STORE_DIR)
+    _clear_directory(dir_abs)
+
+func _clear_directory(path_abs: String) -> void:
+    if not DirAccess.dir_exists_absolute(path_abs):
+        return
+    var dir := DirAccess.open(path_abs)
+    if dir == null:
+        return
+    dir.list_dir_begin()
+    var entry := dir.get_next()
+    while entry != "":
+        if entry == "." or entry == "..":
+            entry = dir.get_next()
+            continue
+        var entry_path := path_abs.path_join(entry)
+        if dir.current_is_dir():
+            _clear_directory(entry_path)
+            DirAccess.remove_absolute(entry_path)
+        else:
+            DirAccess.remove_absolute(entry_path)
+        entry = dir.get_next()
+    dir.list_dir_end()
+    DirAccess.remove_absolute(path_abs)

--- a/addons/local_agents/tests/test_agent_integration.gd
+++ b/addons/local_agents/tests/test_agent_integration.gd
@@ -1,0 +1,104 @@
+@tool
+extends SceneTree
+
+var _captured_outputs: Array = []
+
+class MockAgentNode:
+    extends Node
+
+    signal message_emitted(role, content)
+    signal action_requested(action, params)
+
+    var history: Array = []
+    var actions: Array = []
+
+    func think(prompt: String, extra_options := {}) -> Dictionary:
+        history.append({"role": "user", "content": prompt})
+        var reply := "Echo: %s" % prompt
+        history.append({"role": "assistant", "content": reply})
+        emit_signal("message_emitted", "assistant", reply)
+        return {
+            "ok": true,
+            "text": reply,
+        }
+
+    func add_message(role: String, content: String) -> void:
+        history.append({"role": role, "content": content})
+
+    func get_history() -> Array:
+        var copy: Array = []
+        for entry in history:
+            copy.append(entry.duplicate(true))
+        return copy
+
+    func clear_history() -> void:
+        history.clear()
+
+    func say(text: String, options := {}) -> bool:
+        actions.append({
+            "action": "say",
+            "text": text,
+            "options": options.duplicate(true),
+        })
+        return true
+
+    func listen(options := {}) -> String:
+        return "heard"
+
+    func enqueue_action(name: String, params := {}) -> void:
+        actions.append({
+            "action": name,
+            "params": params.duplicate(true),
+        })
+        emit_signal("action_requested", name, params)
+
+func _init() -> void:
+    var agent := LocalAgentsAgent.new()
+    var mock := MockAgentNode.new()
+    agent.agent_node = mock
+
+    agent.connect("model_output_received", Callable(self, "_on_model_output"))
+
+    var result := agent.think("Hello integration")
+    assert(result.get("ok", false))
+    var text := String(result.get("text", ""))
+    assert(text.begins_with("Echo:"))
+    assert(_captured_outputs.size() == 1)
+
+    assert(agent.history.size() == 2)
+    assert(agent.history[0].get("role") == "user")
+    assert(agent.history[1].get("role") == "assistant")
+
+    var node_history := agent.get_history()
+    assert(node_history.size() == 2)
+    assert(node_history[0].get("role") == "user")
+
+    agent.clear_history()
+    assert(agent.history.is_empty())
+    assert(mock.history.is_empty())
+
+    agent.set_history([
+        {"role": "user", "content": "ping"},
+        {"role": "assistant", "content": "pong"},
+    ])
+    assert(agent.history.size() == 2)
+    assert(mock.history.size() == 2)
+
+    agent.enqueue_action("wave", {"speed": 2})
+    assert(mock.actions.size() >= 1)
+    assert(mock.actions[mock.actions.size() - 1].get("action") == "wave")
+
+    var say_ok := agent.say("speak", {"volume": 0.5})
+    assert(say_ok)
+    assert(mock.actions[mock.actions.size() - 1].get("action") == "say")
+
+    var heard := agent.listen({})
+    assert(heard == "heard")
+
+    agent.queue_free()
+
+    print("Local Agents integration tests passed")
+    quit()
+
+func _on_model_output(text: String) -> void:
+    _captured_outputs.append(text)

--- a/addons/local_agents/tests/test_agent_runtime_heavy.gd
+++ b/addons/local_agents/tests/test_agent_runtime_heavy.gd
@@ -1,0 +1,67 @@
+@tool
+extends SceneTree
+
+func _init() -> void:
+    if not Engine.has_singleton("AgentRuntime"):
+        push_error("AgentRuntime singleton unavailable. Build the GDExtension before running tests.")
+        quit()
+        return
+
+    var runtime := Engine.get_singleton("AgentRuntime")
+    if runtime == null:
+        push_error("AgentRuntime singleton missing.")
+        quit()
+        return
+
+    var model_path := OS.get_environment("LOCAL_AGENTS_TEST_GGUF")
+    if model_path.strip_edges() == "":
+        print("Skipping heavy AgentRuntime test. Set LOCAL_AGENTS_TEST_GGUF to a GGUF model path to enable it.")
+        quit()
+        return
+
+    var resolved_path := _normalize_path(model_path)
+    if not FileAccess.file_exists(resolved_path):
+        push_error("Heavy test model not found at %s" % resolved_path)
+        quit()
+        return
+
+    var loaded := bool(runtime.call("load_model", resolved_path, {
+        "context_size": 64,
+        "embedding": true,
+        "max_tokens": 16,
+        "n_gpu_layers": 0,
+    }))
+    if not loaded:
+        push_error("Failed to load GGUF model for heavy test")
+        quit()
+        return
+
+    if not bool(runtime.call("is_model_loaded")):
+        push_error("Model did not report as loaded for heavy test")
+        runtime.call("unload_model")
+        quit()
+        return
+
+    var embedding: PackedFloat32Array = runtime.call("embed_text", "Local Agents heavy test", {})
+    assert(not embedding.is_empty())
+
+    var response: Dictionary = runtime.call("generate", {
+        "history": [
+            {"role": "system", "content": "You are verifying Local Agents."},
+            {"role": "user", "content": "Reply with a short acknowledgement."},
+        ],
+        "prompt": "Say ok.",
+        "options": {"max_tokens": 8},
+    })
+    assert(response.get("ok", false))
+    assert(String(response.get("text", "")).length() > 0)
+
+    runtime.call("unload_model")
+
+    print("Local Agents heavy runtime test passed")
+    quit()
+
+func _normalize_path(path: String) -> String:
+    if path.begins_with("res://") or path.begins_with("user://"):
+        return ProjectSettings.globalize_path(path)
+    return path

--- a/addons/local_agents/tests/test_agent_utilities.gd
+++ b/addons/local_agents/tests/test_agent_utilities.gd
@@ -1,0 +1,60 @@
+@tool
+extends SceneTree
+
+func _init() -> void:
+    var agent := LocalAgentsAgent.new()
+
+    assert(agent._normalize_path("") == "")
+
+    var res_path := "res://addons/local_agents/plugin.cfg"
+    var res_abs := ProjectSettings.globalize_path(res_path)
+    assert(agent._normalize_path(res_path) == res_abs)
+
+    var user_path := "user://local_agents/tests/sample.txt"
+    var user_abs := ProjectSettings.globalize_path(user_path)
+    assert(agent._normalize_path(user_path) == user_abs)
+
+    var absolute_path := "/tmp/local_agents_demo"
+    assert(agent._normalize_path(absolute_path) == absolute_path)
+
+    assert(not agent._is_absolute_path("relative/path"))
+    assert(agent._is_absolute_path("/absolute"))
+    assert(agent._is_absolute_path("C:\\demo"))
+
+    var tts_abs := ProjectSettings.globalize_path("user://local_agents/tts")
+    _clear_directory(tts_abs)
+
+    var first := agent._allocate_tts_path()
+    OS.delay_msec(5)
+    var second := agent._allocate_tts_path()
+
+    assert(first != "")
+    assert(second != "")
+    assert(first != second)
+
+    var tts_dir_abs := ProjectSettings.globalize_path("user://local_agents/tts")
+    assert(DirAccess.dir_exists_absolute(tts_dir_abs))
+
+    print("Local Agents utility tests passed")
+    quit()
+
+func _clear_directory(path_abs: String) -> void:
+    if not DirAccess.dir_exists_absolute(path_abs):
+        return
+    var dir := DirAccess.open(path_abs)
+    if dir == null:
+        return
+    dir.list_dir_begin()
+    var entry := dir.get_next()
+    while entry != "":
+        if entry == "." or entry == "..":
+            entry = dir.get_next()
+            continue
+        var entry_path := path_abs.path_join(entry)
+        if dir.current_is_dir():
+            _clear_directory(entry_path)
+            DirAccess.remove_absolute(entry_path)
+        else:
+            DirAccess.remove_absolute(entry_path)
+        entry = dir.get_next()
+    dir.list_dir_end()

--- a/addons/local_agents/tests/test_smoke_agent.gd
+++ b/addons/local_agents/tests/test_smoke_agent.gd
@@ -1,0 +1,35 @@
+@tool
+extends SceneTree
+
+func _init() -> void:
+    if not ClassDB.class_exists("AgentNode"):
+        push_error("AgentNode class unavailable. Build the GDExtension before running tests.")
+        quit()
+        return
+
+    var agent := LocalAgentsAgent.new()
+    agent.name = "SmokeAgent"
+    var root := get_root()
+    if root:
+        root.add_child(agent)
+
+    if not agent.is_node_ready():
+        agent._ready()
+
+    assert(agent.agent_node != null)
+    assert(agent.agent_node.get_parent() == agent)
+    assert(agent.history.is_empty())
+
+    agent.submit_user_message("ping")
+    assert(agent.history.size() == 1)
+    assert(agent.history[0].get("role") == "user")
+
+    agent.clear_history()
+    assert(agent.history.is_empty())
+
+    if root and agent.is_inside_tree():
+        root.remove_child(agent)
+    agent.queue_free()
+
+    print("Local Agents smoke test passed")
+    quit()

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -33,9 +33,14 @@ if [[ -z "${FOUND_EXT}" ]]; then
 fi
 
 TEST_SCRIPTS=(
-    "addons/local_agents/tests/test_network_graph.gd"
+    "addons/local_agents/tests/test_smoke_agent.gd"
+    "addons/local_agents/tests/test_agent_utilities.gd"
+    "addons/local_agents/tests/test_agent_integration.gd"
     "addons/local_agents/tests/test_conversation_store.gd"
     "addons/local_agents/tests/test_project_graph_service.gd"
+    "addons/local_agents/tests/test_network_graph.gd"
+    "addons/local_agents/tests/test_agent_e2e.gd"
+    "addons/local_agents/tests/test_agent_runtime_heavy.gd"
 )
 
 echo "==> Running editor script check"


### PR DESCRIPTION
## Summary
- add smoke, unit, integration, end-to-end, and heavy runtime test scripts for Local Agents
- register the new suites with scripts/run_tests.sh and document the expanded coverage in the README

## Testing
- not run (Godot binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e80b1675688329bf4185777d2e9671